### PR TITLE
Added missing closing `/` symbol in `en` translation

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -21,7 +21,7 @@
       },
       "visitKyber": {
         "title": "Learn More",
-        "body": "Visit <1>the official site<1><br/>to download from it"
+        "body": "Visit <1>the official site</1><br/>to download from it"
       }
     },
     "host": {


### PR DESCRIPTION
Added missing closing `/` symbol in `en` translation

Closes #14 